### PR TITLE
Fixed Bug of open issue #16 "Some teams have not played all seasons"

### DIFF
--- a/src/frontend/src/pages/TeamPage.js
+++ b/src/frontend/src/pages/TeamPage.js
@@ -49,7 +49,7 @@ export const TeamPage = () => {
         </div>
         {team.matches.slice(1).map(match => <MatchSmallCard key={match.id} teamName={team.teamName} match={match} />)}
         <div className="more-link">
-        <Link to={`/teams/${teamName}/matches/${process.env.REACT_APP_DATA_END_YEAR}`}>More ></Link>
+        <Link to={`/teams/${teamName}/matches/${team.matches[0].date.slice(0,4)}`}>More ></Link>
         </div>
         </div>
     );


### PR DESCRIPTION
Some teams have not played all seasons so on clicking more it displays an empty page for those teams

Providing link {/teams/${teamName}/matches/${team.matches[0].date.slice(0,4)} instead of {`/teams/${teamName}/matches/${process.env.REACT_APP_DATA_END_YEAR}`}