### PR TITLE
Use setLinesToSkip to skip the header line of the CSV file

### DIFF
--- a/src/main/java/io/javabrains/ipldashboard/data/BatchConfig.java
+++ b/src/main/java/io/javabrains/ipldashboard/data/BatchConfig.java
@@ -37,13 +37,17 @@ public class BatchConfig {
 
     @Bean
     public FlatFileItemReader<MatchInput> reader() {
-        return new FlatFileItemReaderBuilder<MatchInput>().name("MatchItemReader")
+        FlatFileItemReader<MatchInput> flatFileItemReader = new FlatFileItemReaderBuilder<MatchInput>()
+                .name("MatchItemReader")
                 .resource(new ClassPathResource("match-data.csv")).delimited().names(FIELD_NAMES)
                 .fieldSetMapper(new BeanWrapperFieldSetMapper<MatchInput>() {
                     {
                         setTargetType(MatchInput.class);
                     }
                 }).build();
+
+        flatFileItemReader.setLinesToSkip(1);
+        return flatFileItemReader;
     }
 
     @Bean

--- a/src/main/resources/match-data.csv
+++ b/src/main/resources/match-data.csv
@@ -1,3 +1,4 @@
+id,city,date,player_of_match,venue,neutral_venue,team1,team2,toss_winner,toss_decision,winner,result,result_margin,eliminator,method,umpire1,umpire2
 335982,Bangalore,2008-04-18,BB McCullum,M Chinnaswamy Stadium,0,Royal Challengers Bangalore,Kolkata Knight Riders,Royal Challengers Bangalore,field,Kolkata Knight Riders,runs,140,N,NA,Asad Rauf,RE Koertzen
 335983,Chandigarh,2008-04-19,MEK Hussey,"Punjab Cricket Association Stadium, Mohali",0,Kings XI Punjab,Chennai Super Kings,Chennai Super Kings,bat,Chennai Super Kings,runs,33,N,NA,MR Benson,SL Shastri
 335984,Delhi,2008-04-19,MF Maharoof,Feroz Shah Kotla,0,Delhi Capitals,Rajasthan Royals,Rajasthan Royals,bat,Delhi Capitals,wickets,9,N,NA,Aleem Dar,GA Pratapkumar


### PR DESCRIPTION
Header line is added back in the CSV file. FlatFileItemReader.setLinesToSkip() is used to skip that header line when we are reading the data from the CSV file.
The advantage is that if we use setLinesToSkip, we don't need to modify the CSV file; we can use it as it is.